### PR TITLE
"migrate" to python3

### DIFF
--- a/octoprint_BetterHeaterTimeout/__init__.py
+++ b/octoprint_BetterHeaterTimeout/__init__.py
@@ -98,6 +98,7 @@ class BetterHeaterTimeoutPlugin(
 
 
 __plugin_name__ = "BetterHeaterTimeout"
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 def __plugin_load__():
 	global __plugin_implementation__

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_BetterHeaterTimeout"
 plugin_name = "OctoPrint-BetterHeaterTimeout"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "1.2.0"
+plugin_version = "1.3.0"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
Seems to load without additional functional changes (Raspberry Pi octopi 0.17.0 host, python 3.7.3, Octoprint 1.4.2)

- add `__plugin_pythoncompat__ = ">=2.7,<4"`
- bump plugin version

re: #10 #11 #12 #13 