### PR TITLE
Added a separate bed timeout enable

### DIFF
--- a/octoprint_BetterHeaterTimeout/__init__.py
+++ b/octoprint_BetterHeaterTimeout/__init__.py
@@ -14,7 +14,7 @@ class BetterHeaterTimeoutPlugin(
 		self._temp_statuses = dict();
 
 	def on_printer_add_temperature(self, data):
-		if not self._settings.get(["enabled"]) or not self._printer.is_ready():
+		if (not self._settings.get(["enabled"]) and not self._settings.get(["bedEnabled"])) or not self._printer.is_ready():
 			self._temp_statuses = dict();
 
 		time = data["time"]
@@ -38,7 +38,8 @@ class BetterHeaterTimeoutPlugin(
 					else:
 						time_elapsed = time - self._temp_statuses[key]["start"]
 						timeout = self._settings.get_float(["bedTimeout" if key == "bed" else "timeout"])
-						if time_elapsed >= timeout:
+						is_enabled = self._settings.get(["bedEnabled" if key == "bed" else "enabled"])
+						if time_elapsed >= timeout and is_enabled:
 							def send_gcode_lines(setting_name):
 								self._printer.commands(self._settings.get([setting_name]) \
 									.replace("$heater", key) \
@@ -73,6 +74,7 @@ class BetterHeaterTimeoutPlugin(
 			bedTimeout=600,
 			timeout=600,
 			enabled=True,
+			bedEnabled=True,
 			since_change=True,
 			before_gcode='',
 			after_gcode='M117 $heater timed out',

--- a/octoprint_BetterHeaterTimeout/templates/BetterHeaterTimeout_settings.jinja2
+++ b/octoprint_BetterHeaterTimeout/templates/BetterHeaterTimeout_settings.jinja2
@@ -3,33 +3,39 @@
 	<div class="control-group">
 		<label class="control-label">
 			<input type="checkbox" style="margin-top: -2px; margin-right: 5px;" data-bind="checked: settings.plugins.BetterHeaterTimeout.enabled"/>
-			{{ _('Timeout') }}
+			{{ _('Tool') }}
 		</label>
 		<div class="controls">
 			<div class="input-append">
 				<input class="input-mini text-right" type="number" data-bind="value: settings.plugins.BetterHeaterTimeout.timeout, enable: settings.plugins.BetterHeaterTimeout.enabled"/>
 				<span class="add-on">s</span>
 			</div>
-			<select data-bind="
-				options: [true, false],
-				optionsText: b => b ? 'after target temp changes' : 'after heating starts',
-				value: settings.plugins.BetterHeaterTimeout.since_change,
-					enable: settings.plugins.BetterHeaterTimeout.enabled
-
-			"></select>
 		</div>
 	</div>
 	<div class="control-group">
 		<label class="control-label">
+			<input type="checkbox" style="margin-top: -2px; margin-right: 5px;" data-bind="checked: settings.plugins.BetterHeaterTimeout.bedEnabled"/>
 			{{ _('Bed') }}
 		</label>
 		<div class="controls">
 			<div class="input-append">
-				<input class="input-mini text-right" type="number" data-bind="value: settings.plugins.BetterHeaterTimeout.bedTimeout, enable: settings.plugins.BetterHeaterTimeout.enabled"/>
+				<input class="input-mini text-right" type="number" data-bind="value: settings.plugins.BetterHeaterTimeout.bedTimeout, enable: settings.plugins.BetterHeaterTimeout.bedEnabled"/>
 				<span class="add-on">s</span>
 			</div>
 		</div>
 	</div>
+	<div class="control-group">
+		<label class="control-label">
+			{{ _('From') }}
+		</label>
+		<div class="controls">
+			<select data-bind="
+				options: [true, false],
+				optionsText: b => b ? 'after target temp changes' : 'after heating starts',
+				value: settings.plugins.BetterHeaterTimeout.since_change
+			"></select>
+		</div>
+	</div>	
 	<h4>{{ _('GCODEs') }}</h4>
 	<div class="control-group">
 		<label class="control-label">{{ _('Before GCODE') }}</label>


### PR DESCRIPTION
I added a new setting/checkbox to control the Bed Heater timeout separately from the Extruder timeout. Using the two "enable" settings will allow a user the option of the plugin shutting off the Extruder, the Bed, or both depending on their needs.  I personally needed this so that the plugin didn't shut off my Bed if a print paused for a filament change.

The plugin version in this PR may be installed using URL:
https://github.com/MachX428/OctoPrint-BetterHeaterTimeout/archive/BedEnable.zip