### PR TITLE
Prevent/reduce multiple triggers

### DIFF
--- a/octoprint_BetterHeaterTimeout/__init__.py
+++ b/octoprint_BetterHeaterTimeout/__init__.py
@@ -45,7 +45,7 @@ class BetterHeaterTimeoutPlugin(
 									.replace("$time_elapsed", str(time_elapsed)) \
 									.replace("$timeout", str(timeout)) \
 									.split("\n"))
-
+							del self._temp_statuses[key]                # Reset our timer to prevent/reduce multiple triggers in the case of long running commands on the target machine
 							send_gcode_lines("before_gcode");
 							self._printer.set_temperature(key, 0);
 							payload = dict(


### PR DESCRIPTION
### Commit Comment
This change will reset our timeout timer when a timeout
event is triggered. This is to prevent/reduce multiple triggers
if the target machine has a long running command in play
and  doesn't process the temperature reset immediately.
If the timeout delay is short enough and the target machine
has still not reset the temperature, duplicate events will still
trigger every <timeout_delay> seconds.

### Overview
This should address issues #17, although I am running Klipper at the moment, not Marlin, so I can't test that specific case. In my case I always get a duplicate HeaterTimeoutEvent for the Bed when the timeout_delay for the Tool and Bed are set to the same value, which this fix solves.

### More Info - Forcing the problem
During my testing I noticed that when a temperature change is sent by OctoPrint (either through sending gcode or the self._printer.set_temperature() function),  another callback gets queued up at that point reflecting the heater targets AT THAT POINT. So I added several "M140 S60" gcodes to the "Before GCODE" settings of the plugin. Each of these would queue up another temperature event callback, and exacerbated my problem. I figured this also simulates what would happen in issue #17 if I was running Marlin and it was providing temperature updates but not processing new commands while doing a bed mesh. The result I got was a bunch of event spam just like what was described in issue #17. Once I introduced my fix, not only did my problem go away, but this "forced" problem went away as well, and all worked normally.

### Details on the Bug and Fix

In the callback when the timeout_delay is reached, the plugin processes the tool timeout first, and issues a set_temperature() update to set the target of the tool to 0. AT THIS POINT, another temperature event happens which queues up another callback. In the temperature data for this new callback, the targets for all heaters would be identical to the current data, except now the target for the tool heater is set to 0. (The bed target would still be set to whatever it was). Then the plugin would continue on and now process the Bed timeout. Here too a timeout event would be triggered for the Bed and the plugin would set the bed's target to 0. Doing so would add yet another temperature callback to the queue. This time both Tool and Bed targets would be at 0. The initial callback would then end, and now the second callback that was queued would be processed. The Tool target here was now at 0, so no additional event was triggered for the tool and the plugin would reset the Tool timer. But the Bed target in this data still had the original target. So now a second event was triggered for the bed and the Plugin again set the temperature to 0. This callback would end and the now  processing of the third callback would begin. The bed target would now reflect 0, and the plugin would reset the bed timeout.

The fix just resets the timer immediately within the callback that the timeout event happens. Therefore in future callbacks, no further events get triggered until/if the time_elapsed once again grows to the point it exceeds the set delay.

So in my case it prevents 1 duplicate event. But in a case where the target machine keeps reporting temperature but not updating the heater targets because of a long running command, I could totally see how a bunch of spam would happen.

### One other "issue"
Incidentally, I also noticed there is another "issue" in that the plugin relies on temperature callbacks to work. Since the plugin will only get these callbacks when it receives a temperature update from the target machine - if it never gets any, it doesn't get an update and so doesn't trigger a timeout until it finally does. So if I have, for example, a timeout set to 5 seconds and something on the target machine causes it to not send an update for a minute, the timeout will trigger at a minute instead of 5 seconds. This obviously has nothing to do with my fix, and the issue is present in the current unmodified plugin as well. I SUPPOSE this could be fixed if the plugin were constructed to receive regular callbacks independent of temperature events and
tracked time elapsed that way. But I don't really think this is a huge deal as is because presumably if you aren't getting temperature updates from the target machine, it isn't communicating and therefore would probably not be able to process a set temperature gcode even if OctoPrint were to send it.